### PR TITLE
feature: Add support for Promise and allow other functions to wait for the return.

### DIFF
--- a/lib/als-types.ts
+++ b/lib/als-types.ts
@@ -1,8 +1,13 @@
 export type StorageType = Map<string, any>
 
+export type UnwrapPromise<T> = T extends Promise<infer U> ? U : T
+
 export type AsynchronousLocalStorage = {
   get: <T>(key: string) => T | undefined
   set: <T>(key: string, value: T) => void
-  runWith: (callback: () => void, defaults?: Record<string, any>) => void
+  runWith: <T extends (...args: any[]) => any, R extends ReturnType<T>>(
+    callback: T,
+    defaults?: Record<string, any>
+  ) => UnwrapPromise<R>
   storageImplementation: string
 }

--- a/test/als.spec.ts
+++ b/test/als.spec.ts
@@ -21,15 +21,6 @@ describe('AsyncLocalStorage tests', () => {
           { key: 'value' }
         )
       })
-
-      it('runWith with synchronous callback', () => {
-        const result = als.runWith(() => {
-          als.set('key', 'value')
-          return als.get('key')
-        })
-
-        expect(result).toBe('value')
-      })
     })
 
     describe('if set is called within context', () => {

--- a/test/als.spec.ts
+++ b/test/als.spec.ts
@@ -21,6 +21,15 @@ describe('AsyncLocalStorage tests', () => {
           { key: 'value' }
         )
       })
+
+      it('runWith with synchronous callback', () => {
+        const result = als.runWith(() => {
+          als.set('key', 'value')
+          return als.get('key')
+        })
+
+        expect(result).toBe('value')
+      })
     })
 
     describe('if set is called within context', () => {
@@ -30,6 +39,26 @@ describe('AsyncLocalStorage tests', () => {
           expect(als.get('key')).toBe('value')
           done()
         })
+      })
+    })
+
+    describe('test runWith', () => {
+      it('runWith with synchronous callback', () => {
+        const result = als.runWith(() => {
+          als.set('key', 'value')
+          return als.get('key')
+        })
+
+        expect(result).toBe('value')
+      })
+
+      it('runWith with asynchronous callback', async () => {
+        const result = await als.runWith(async () => {
+          als.set('key', 'value')
+          return Promise.resolve(als.get('key'))
+        })
+
+        expect(result).toBe('value')
       })
     })
   } else {


### PR DESCRIPTION
Description:
When I use this extension package, I find that I cannot determine how long it will take to return results. This is because the runWith method does not wait for the execution result. I am using a serverless Lambda architecture, and I hope that all my executions are predictable.